### PR TITLE
Remove deprecated jcenter (gradle 9)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,7 +16,7 @@ def _minSdkVersion      = safeExtGet('minSdkVersion', 16)
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.4.1'
@@ -43,7 +43,7 @@ android {
 repositories {
     mavenLocal()
     google()
-    jcenter()
+    mavenCentral()
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
         url "$rootDir/../node_modules/react-native/android"


### PR DESCRIPTION
Starting from gradle 9, jcenter is removed, see also https://github.com/gradle/gradle/issues/34504