### PR TITLE
Replace deprecated getWindowDisplayMetrics for RN 0.87.0

### DIFF
--- a/android/src/main/java/com/github/amarcruz/rntextsize/RNTextSizeModule.java
+++ b/android/src/main/java/com/github/amarcruz/rntextsize/RNTextSizeModule.java
@@ -460,7 +460,6 @@ class RNTextSizeModule extends ReactContextBaseJavaModule {
     /**
      * Retuns the current density.
      */
-    @SuppressWarnings("deprecation")
     private float getCurrentDensity() {
         return DisplayMetricsHolder.getScreenDisplayMetrics().density;
     }

--- a/android/src/main/java/com/github/amarcruz/rntextsize/RNTextSizeModule.java
+++ b/android/src/main/java/com/github/amarcruz/rntextsize/RNTextSizeModule.java
@@ -462,7 +462,7 @@ class RNTextSizeModule extends ReactContextBaseJavaModule {
      */
     @SuppressWarnings("deprecation")
     private float getCurrentDensity() {
-        return DisplayMetricsHolder.getWindowDisplayMetrics().density;
+        return DisplayMetricsHolder.getScreenDisplayMetrics().density;
     }
 
     private static final String[] FILE_EXTENSIONS = {".ttf", ".otf"};


### PR DESCRIPTION
See GitHub commit which did remove the getWindowDisplayMetrics function
https://github.com/react/react-native/commit/82536f230fc14d9433fc006224e3b3da24d5838f